### PR TITLE
✨ Telegram - username format + bold/italic text

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ discordClient.on("message", message => {
 	// attachmentUrls is empty when there are no attachments so we can be just lazy
 	var finalMessageContent = message.content.replace(/<@.*>/gi, '');
 
-	var text = `[DISCORD] ${message.author.username}#${message.author.discriminator}: `;
+	var text = `**[DISCORD] ${message.author.username} (${message.author.username}#${message.author.discriminator}):**\n`;
 	text += finalMessageContent
 	text += ` ${attachmentUrls.join(' ')}`;
 	text += mentioned_usernames.join(" ");

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ discordClient.on("message", message => {
 	// attachmentUrls is empty when there are no attachments so we can be just lazy
 	var finalMessageContent = message.content.replace(/<@.*>/gi, '');
 	// convert bold text for telegram markdown
-	finalMessageContent = finalMessageContent.replace(/\*\*/g, '');
+	finalMessageContent = finalMessageContent.replace(/\*\*/g, '*');
 
 	var text = `*\[DISCORD\] ${message.author.username} (${message.author.username}#${message.author.discriminator}):*\n`;
 	text += finalMessageContent

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ discordClient.on("message", message => {
 	// attachmentUrls is empty when there are no attachments so we can be just lazy
 	var finalMessageContent = message.content.replace(/<@.*>/gi, '');
 
-	var text = `**[DISCORD] ${message.author.username} (${message.author.username}#${message.author.discriminator}):**\n`;
+	var text = `<b>[DISCORD] ${message.author.username} (${message.author.username}#${message.author.discriminator}):</b>\n`;
 	text += finalMessageContent
 	text += ` ${attachmentUrls.join(' ')}`;
 	text += mentioned_usernames.join(" ");

--- a/server.js
+++ b/server.js
@@ -33,8 +33,10 @@ discordClient.on("message", message => {
 
 	// attachmentUrls is empty when there are no attachments so we can be just lazy
 	var finalMessageContent = message.content.replace(/<@.*>/gi, '');
+	// convert bold text for telegram markdown
+	finalMessageContent = finalMessageContent.replace('**', '*')
 
-	var text = `**[DISCORD] ${message.author.username} (${message.author.username}#${message.author.discriminator}):**\n`;
+	var text = `*\[DISCORD\] ${message.author.username} (${message.author.username}#${message.author.discriminator}):*\n`;
 	text += finalMessageContent
 	text += ` ${attachmentUrls.join(' ')}`;
 	text += mentioned_usernames.join(" ");

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ discordClient.on("message", message => {
 	// attachmentUrls is empty when there are no attachments so we can be just lazy
 	var finalMessageContent = message.content.replace(/<@.*>/gi, '');
 	// convert bold text for telegram markdown
-	finalMessageContent = finalMessageContent.replace('**', '*')
+	finalMessageContent = finalMessageContent.replace(/\*\*/g, '');
 
 	var text = `*\[DISCORD\] ${message.author.username} (${message.author.username}#${message.author.discriminator}):*\n`;
 	text += finalMessageContent

--- a/server.js
+++ b/server.js
@@ -42,7 +42,7 @@ discordClient.on("message", message => {
 	telegram.sendMessage({
 		chat_id: TELEGRAM_CHAT_ID,
 		text: text,
-		parse_mode: 'MarkdownV2'
+		parse_mode: 'markdown'
 	});
 });
 

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ discordClient.on("message", message => {
 	// attachmentUrls is empty when there are no attachments so we can be just lazy
 	var finalMessageContent = message.content.replace(/<@.*>/gi, '');
 
-	var text = `<b>[DISCORD] ${message.author.username} (${message.author.username}#${message.author.discriminator}):</b>\n`;
+	var text = `**[DISCORD] ${message.author.username} (${message.author.username}#${message.author.discriminator}):**\n`;
 	text += finalMessageContent
 	text += ` ${attachmentUrls.join(' ')}`;
 	text += mentioned_usernames.join(" ");
@@ -42,6 +42,7 @@ discordClient.on("message", message => {
 	telegram.sendMessage({
 		chat_id: TELEGRAM_CHAT_ID,
 		text: text,
+		parse_mode: 'MarkdownV2'
 	});
 });
 


### PR DESCRIPTION
## What's new?
- Aligns the **Telegram** username format with the **Discord** username format
- Fixes **bold** & _italic_ text from **Discord** :arrow_right: **Telegram**

#### Discord Username format
![discord-username-format](https://user-images.githubusercontent.com/24852597/140641798-c134d4f2-87e2-4198-962e-82388311d295.png)

#### New Telegram Username format
![new-telegram-username-format](https://user-images.githubusercontent.com/24852597/140641800-d83090a2-c68b-4dfa-86ef-0688326cf0f5.png)

#### Old Telegram Username format
![old-telegram-username-format](https://user-images.githubusercontent.com/24852597/140641802-d8613226-4b91-443a-9eb3-cc0cd17bd9fb.png)
