### PR TITLE
✨ Discord - Added bold, italic and hyperlink conversion

### DIFF
--- a/server.js
+++ b/server.js
@@ -79,17 +79,17 @@ telegram.on("message", async function (message) {
 		}
 		text = message.text;
 
-		// convert bold & italic Telegram text for Discord markdown
+		// convert bold, italic & hyperlink Telegram text for Discord markdown
 		if (message.entities) {
-			text = convert_bold_italic_telegram_text(text, message.entities);
+			text = convert_text_telegram_to_discord(text, message.entities);
 		}
 
 	} else {
 		text = message.caption;
 
-		// convert bold & italic Telegram text for Discord markdown
+		// convert bold, italic & hyperlink Telegram text for Discord markdown
 		if (message.caption_entities) {
-			text = convert_bold_italic_telegram_text(text, message.caption_entities);
+			text = convert_text_telegram_to_discord(text, message.caption_entities);
 		}
 
 		if (message.document) {
@@ -121,7 +121,7 @@ telegram.on("message", async function (message) {
 	}
 });
 
-function convert_bold_italic_telegram_text(text, entities) {
+function convert_text_telegram_to_discord(text, entities) {
 	var convert;
 	var start_format;
 	var end_format;

--- a/server.js
+++ b/server.js
@@ -78,8 +78,20 @@ telegram.on("message", async function (message) {
 			return;
 		}
 		text = message.text;
+
+		// convert bold & italic Telegram text for Discord markdown
+		if (message.entities) {
+			text = convert_bold_italic_telegram_text(text, message.entities);
+		}
+
 	} else {
 		text = message.caption;
+
+		// convert bold & italic Telegram text for Discord markdown
+		if (message.caption_entities) {
+			text = convert_bold_italic_telegram_text(text, message.caption_entities);
+		}
+
 		if (message.document) {
 			fileId = message.document.file_id;
 		} else if (message.sticker) {
@@ -106,5 +118,42 @@ telegram.on("message", async function (message) {
 			avatarURL: profileUrl,
 			files: [fileUrl],
 		});
-	};
+	}
 });
+
+function convert_bold_italic_telegram_text(text, entities) {
+	var convert;
+	var start_format;
+	var end_format;
+	var section_offset = 0
+	var section_end;
+	var section_start;
+
+	entities.forEach(({type, offset, length, url}) => {
+		convert = true;
+		if (type == 'bold') {
+			start_format = '\*\*';
+			end_format = '\*\*';
+		} else if(type == 'italic') {
+			start_format = '\_';
+			end_format = '\_';
+		} else if(type == 'text_link') {
+			start_format = '\*\*';
+			end_format = '\*\* (<' + url + '>)';
+		} else {
+			// Don't convert other entities
+			convert = false;
+		}
+
+		if (convert) {
+			section_start = offset + section_offset;
+			section_end = offset + length + section_offset;
+			// First add end_format, so it won't mess up the string indexes for start_format
+			text = text.slice(0, section_end) + end_format + text.slice(section_end);
+			text = text.slice(0, section_start) + start_format + text.slice(section_start);
+			section_offset += start_format.length + end_format.length;
+		}
+	});
+
+	return text
+}


### PR DESCRIPTION
## What's new?
Added conversion from Telegram :arrow_right: Discord for:
- **Bold**
- _italic_
- [HyperLink](https://duckduckgo.com)

**Note:** Multiple Hyperlinks can be posted nicely below eachother from Telegram :arrow_right: Discord by appending 3 spaces after each HyperLink on Telegram.

#### Telegram message format
![formatting-telegram](https://user-images.githubusercontent.com/24852597/140657625-5a3fca6c-1cf1-4560-9635-fc13ef968c9d.png)

#### Discord after message formatting
![after-discord-formatting-discord](https://user-images.githubusercontent.com/24852597/140657598-f8b1cbc8-0be2-4413-bfe9-aa27348123e6.png)

#### Discord before message formatting
![before-discord-formatting-discord](https://user-images.githubusercontent.com/24852597/140657574-cfa78f0a-4151-4ce1-b8ac-c443818d8697.png)