### PR TITLE
✨ Discord - Forward bot toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@
     - `DISCORD_CHANNEL_ID` - The Discord ChannelId of the channel you want to bridge
     - `DISCORD_WEBHOOK_ID` and `DISCORD_WEBHOOK_TOKEN`. Those are part of the webhook URL you copied. `DISCORD_WEBHOOK_ID` is a 18 characters long int, `DISCORD_WEBHOOK_TOKEN` is a ~70 chars long randomly generated string. Those are seperated by slashes in the url.
     - If you use Heroku, set `HEROKU_DYNO_URL` to make the dyno not timeout. You can find your dyno's URL in Heroku dashboard -> Open app
+    - If you need to forward Discord Bot messages -> Telegram set `DISCORD_FORWARD_BOT` to `true`  (will cause duplicate messages in bridges that forward in both directions)
 
 * Run `npm start` or `node server.js` and you're set!

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ enable_heroku();
 // import env variables
 const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
 const DISCORD_CHANNEL_ID = process.env.DISCORD_CHANNEL_ID;
+const DISCORD_FORWARD_BOT = (process.env.DISCORD_FORWARD_BOT === 'true')
 
 console.log("Telegram chat id: " + TELEGRAM_CHAT_ID);
 console.log("Discord channel id: " + DISCORD_CHANNEL_ID);
@@ -18,7 +19,8 @@ discordClient.on("message", message => {
 	// the program currently check if the message's from a bot to check for duplicates.
 	// This isn't the best method but it's good enough.
 	// A webhook counts as a bot in the discord api, don't ask me why.
-	if (message.channel.id !== DISCORD_CHANNEL_ID || message.author.bot == true) {
+	// Ignore messages from bots if DISCORD_FORWARD_BOT is 'false'
+	if (message.channel.id !== DISCORD_CHANNEL_ID || (message.author.bot && !DISCORD_FORWARD_BOT)) {
 		return;
 	}
 
@@ -50,7 +52,7 @@ discordClient.on("message", message => {
 
 // Telegram -> Discord handler
 telegram.on("message", async function (message) {
-	//console.log(message)
+	// console.log(message)
 	if (message.chat.id != TELEGRAM_CHAT_ID) {
 		return;
 	}


### PR DESCRIPTION
## What's new
Adds an optional setting `DISCORD_BOT_FORWARD`,
- if set to `true` it will forward bot messages from Discord :arrow_right: Telegram.
- If set to `false` (or any other string value, or if the setting is non-existing),
  then it won't forward bot messages from Discord :arrow_right: Telegram.

**Notes:**
- Will cause duplicate messages in bridges in both directions.
- I was mostly interested in `TELEGRAM_BOT_FORWARD`, 
  but I had to scrap this feature because [Telegram doesn't allow bots to read eachothers messages](https://core.telegram.org/bots/faq#why-doesn-39t-my-bot-see-messages-from-other-bots)

#### Telegram view
![discord-bot-forward](https://user-images.githubusercontent.com/24852597/140665204-1aa58dd7-fc15-4a08-955e-d72fb361b77e.png)

