### PR TITLE
⚡ Detect if Heroku is used

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,9 @@ import { telegram, telegramGetFileURL, telegramGetProfilePic } from './backends/
 
 import { enable_heroku } from './utils/heroku.js';
 
-enable_heroku();
+if ("HEROKU_DYNO_URL" in process.env) {
+	enable_heroku();
+}
 
 // import env variables
 const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;


### PR DESCRIPTION
### What's new?
Only run `enable_heroku()` if the `HEROKU_DYNO_URL` has been configured to prevent errors when self-hosting through [`dokku`](https://github.com/dokku/dokku)

#### Before detect Heroku
![before-detect-heroku](https://user-images.githubusercontent.com/24852597/141837326-ba18fa8d-d2ba-43de-b3d6-e7858b7624cf.png)

#### After detect Heroku
![after-detect-heroku](https://user-images.githubusercontent.com/24852597/141841775-931e1ae7-7018-4bad-b02f-c4358b8e1e70.png)

