### PR TITLE
🐞 BugFix - Telegram use last/largest picture in list

### DIFF
--- a/server.js
+++ b/server.js
@@ -109,7 +109,8 @@ telegram.on("message", async function (message) {
 		} else if (message.sticker) {
 			fileId = message.sticker.file_id;
 		} else if (message.photo) {
-			fileId = message.photo[2].file_id;
+			// pick the last/largest picture in the list
+			fileId = message.photo[message.photo.length - 1].file_id;
 		}
 	}
 


### PR DESCRIPTION
## What was wrong?
Due to the hard-coded list index of the images being sent from Telegram :arrow_right: Discord the bridge sometimes crashed,
which lead to a reboot being required.

![telegram-image-error](https://media.discordapp.net/attachments/904808398288207892/914978665459249152/unknown.png)

## What's changed?
Now instead of using a hard-coded list index the bridge will use the last (aka largest) item in the `photo` list.

This has been tested & confirmed working with single images, 2 images grouped & 2 images not grouped.