### PR TITLE
⚡ Telegram - Added 5sec timeout grace time

### DIFF
--- a/backends/telegram.js
+++ b/backends/telegram.js
@@ -8,6 +8,7 @@ export var telegram = new TelegramApi({
 	token: TELEGRAM_BOT_TOKEN,
 	updates: {
 		enabled: true,
+		pooling_timeout: 5000
 	},
 });
 


### PR DESCRIPTION
## What's new?
Added a 5 second timeout grace time to prevent Telegram timeout issues from occurring.

See following for the Telegram `timeout` documentation:
- [Docs - Telegram API `getUpdates() - timeout`](https://core.telegram.org/bots/api#getupdates)
- [Docs - Natsvora/telegram-bot-api `updates.pooling_timeout`](https://github.com/Natsvora/telegram-bot-api#api-configuration)